### PR TITLE
Makefile: upgrade to using docker-compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ environment:
 	export $(cat .env)
 
 build:
-	docker-compose build
+	docker compose build
 
 start:
-	docker-compose up
+	docker compose up
 
 stop:
-	docker-compose down
+	docker compose down
 
 


### PR DESCRIPTION
docker-compose v1 seems to be deprecated, and is no longer maintained. The recommended version is now v2.x, see https://github.com/docker/compose

For this version to work, instead of "docker-compose", the command line is "docker compose". This patch just changes the Makefile to use it.

I tested the change, and it seems to work. But maybe it would be good to add a note in the README stating that docker-compose v2.x should be used.